### PR TITLE
Allow passing props to Widget.

### DIFF
--- a/lib/components/Widgets.js
+++ b/lib/components/Widgets.js
@@ -21,7 +21,7 @@ const Widgets = ({widgets, widgetTypes, onRemove, layout, columnIndex, rowIndex,
         onMove={onMove}
       >
         {
-          createElement(widgetTypes[widget.key].type, { })
+          createElement(widgetTypes[widget.key].type, widgetTypes[widget.key].props)
         }
       </WidgetFrame>
     );


### PR DESCRIPTION
Pass props to WidgetFrame if available.  This allows Dashboard to be wrapped in a higher order component... 

For example:

```javascript
      widgets: {
        AcademicProfile: {
          type: AcademicProfile,
          props: {
            academicProfile: apdata,
            isFetching: false,
          },
        },
      }
```