### PR TITLE
Removed react-dnd DragDropContext wrapping from Dashboard component. …

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,51 @@ class App extends Component {
 }
 ```
 
+Dazzle uses [react-dnd](https://github.com/react-dnd/react-dnd). The default _Dashboard_ component of Dazzle is wrapped by [_DragDropContext_](https://react-dnd.github.io/react-dnd/docs-drag-drop-context.html) of react-dnd.
+So you may want to use react-dnd in your React component hierarchy upper than where you use the _Dashboard_ component of Dazzle. If you do so then you can't let Dazzle creating the _DragDropContext_ because you want to create it yourself upper in the React component hierarchy of your application.
+So forth please use the _DashboardWithoutDndContext_ component of Dazzle and wrapped your own component with _DragDropContext(HTML5Backend)_:
+```javascript
+import React, { Component } from 'react';
+import Dashboard from 'react-dazzle';
+
+// react-dnd
+import { DragDropContext } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+
+// Your widget. Just another react component.
+import CounterWidget from './widgets/CounterWidget';
+
+// Default styles.
+import 'react-dazzle/lib/style/style.css';
+
+class App extends Component {
+  constructor() {
+    this.state = {      
+      widgets: {
+        WordCounter: {
+          type: CounterWidget,
+          title: 'Counter widget',
+        }
+      },
+      layout: {
+        rows: [{
+          columns: [{
+            className: 'col-md-12',
+            widgets: [{key: 'WordCounter'}],
+          }],
+        }],
+      }
+    };
+  }
+
+  render() {
+    return <DashboardWithoutDndContext  widgets={this.state.widgets} layout={this.state.layout}  />
+  }
+}
+
+export default DragDropContext(HTML5Backend)(App);
+```
+
 ## API
 | Props | Type| Description | Required |
 | --- | --- | --- | --- |

--- a/lib/components/Dashboard.js
+++ b/lib/components/Dashboard.js
@@ -1,14 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { DragDropContext } from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
 import LayoutRenderer from './LayoutRenderer';
 
 /**
  * Main dashboard component. This is where all of this starts.
  */
 /* eslint react/prefer-stateless-function: "off" */
-@DragDropContext(HTML5Backend)
 class Dashboard extends Component {
   render() {
     return (

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,2 +1,8 @@
-export { default as default } from './components/Dashboard';
+import { DragDropContext } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+import Dashboard from './components/Dashboard';
+
+const DashboardWithDndContext = DragDropContext(HTML5Backend)(Dashboard);
+export { Dashboard as DashboardWithoutDndContext };
+export { DashboardWithDndContext as default };
 export { addWidget } from './util';


### PR DESCRIPTION
Here is the PR related to our [previous discussion](https://github.com/Raathigesh/dazzle/issues/31)
To be honnest I think this is my very first PR on github!

I'm still not very comfortable with ES6/7 modules so please feel free to modify this if it's not right. I've not added a test because I'm not sure how to write it. But I can confirm Dashboard and DashboardWithoutDndContext run has expected in my React application. Also `yarn test` succeeds.