### PR TITLE
Allow frameComponent to customize the isDragging state

### DIFF
--- a/lib/components/Row.js
+++ b/lib/components/Row.js
@@ -43,6 +43,7 @@ function Row(props) {
         <Widgets
           key={index}
           widgets={column.widgets}
+          containerClassName={column.containerClassName}
           widgetTypes={widgets}
           onRemove={onRemove}
           layout={layout}

--- a/lib/components/Row.js
+++ b/lib/components/Row.js
@@ -43,7 +43,6 @@ function Row(props) {
         <Widgets
           key={index}
           widgets={column.widgets}
-          containerClassName={column.containerClassName}
           widgetTypes={widgets}
           onRemove={onRemove}
           layout={layout}

--- a/lib/components/WidgetFrame.js
+++ b/lib/components/WidgetFrame.js
@@ -100,26 +100,21 @@ class WidgetFrame extends Component {
       isDragging,
     } = this.props;
 
-    let selected = null;
-
     if (frameComponent) {
       // if user provided a custom frame,  use it
-      selected = createElement(frameComponent, {	children,	editable, title, onRemove: this.remove }); // eslint-disable-line max-len
-    } else {
-      // else use the default frame
-      selected = (
-        <DefaultFrame
-          title={title}
-          editable={editable}
-          children={children}
-          onRemove={this.remove}
-        />
-      );
+      return createElement(frameComponent, { children, editable, title, onRemove: this.remove, isDragging }); // eslint-disable-line max-len
     }
+
     const opacity = isDragging ? 0 : 1;
+
     const widgetFrame = (
         <div style={{ opacity }}>
-            {selected}
+            <DefaultFrame
+              title={title}
+              editable={editable}
+              children={children}
+              onRemove={this.remove}
+            />
         </div>
     );
 

--- a/test/components/WidgetFrame.spec.js
+++ b/test/components/WidgetFrame.spec.js
@@ -53,6 +53,7 @@ describe('<WidgetFrame />', () => {
     expect(component.find(DefaultFrame).first().prop('children')).to.equal(children);
     expect(component.find(DefaultFrame).first().prop('editable')).to.equal(editable);
     expect(component.find(DefaultFrame).first().prop('title')).to.equal(title);
+    expect(component.find('WidgetFrame div').first().prop('style').opacity).to.equal(1);
   });
 
   it('DefaultFrame onRemove should be called when close is clicked', () => {
@@ -131,6 +132,7 @@ describe('<WidgetFrame />', () => {
     let title = 'Widget Title';
     let OriginalWidgetFrame = WidgetFrame.DecoratedComponent;
     let identity = (el) => el;
+    const isDragging = false;
     const component = mount(
       <ContainerWithDndContext>
         <OriginalWidgetFrame
@@ -141,6 +143,7 @@ describe('<WidgetFrame />', () => {
           frameComponent={TestCustomFrame}
           connectDragSource={identity}
           connectDropTarget={identity}
+          isDragging={isDragging}
         />
       </ContainerWithDndContext>
     );
@@ -148,5 +151,6 @@ describe('<WidgetFrame />', () => {
     expect(component.find(TestCustomFrame).first().prop('children')).to.equal(children);
     expect(component.find(TestCustomFrame).first().prop('editable')).to.equal(editable);
     expect(component.find(TestCustomFrame).first().prop('title')).to.equal(title);
+    expect(component.find(TestCustomFrame).first().prop('isDragging')).to.equal(isDragging);
   });
 });


### PR DESCRIPTION
`WidgetFrame` adds an extra `div` tag with `style` attribute and can't be customized. This also allows to handle the `isDragging` state.

## Breaking Changes
This causes custom frameComponent to stop changing `opacity` since this should be now handled separately.