### PR TITLE
Pass user settings to WidgetFrame

### DIFF
--- a/lib/components/WidgetFrame.js
+++ b/lib/components/WidgetFrame.js
@@ -171,6 +171,11 @@ WidgetFrame.propTypes = {
   frameComponent: PropTypes.func,
 
   /**
+   * User provided settings for be use by custom widget frame.
+   */
+  frameSettings: PropTypes.object.optional,
+
+  /**
    * Name of the widget.
    */
   widgetName: PropTypes.string,
@@ -199,6 +204,10 @@ WidgetFrame.propTypes = {
    * Function that should be called when a widget is about to be removed.
    */
   onRemove: PropTypes.func,
+};
+
+WidgetFrame.defaultProps = {
+  frameSettings: {},
 };
 
 export default WidgetFrame;

--- a/lib/components/WidgetFrame.js
+++ b/lib/components/WidgetFrame.js
@@ -180,7 +180,7 @@ WidgetFrame.propTypes = {
   /**
    * User provided settings for be use by custom widget frame.
    */
-  frameSettings: PropTypes.object.optional,
+  frameSettings: PropTypes.object,
 
   /**
    * Name of the widget.

--- a/lib/components/WidgetFrame.js
+++ b/lib/components/WidgetFrame.js
@@ -95,6 +95,7 @@ class WidgetFrame extends Component {
       children,
       editable,
       title,
+      frameSettings,
       connectDragSource,
       connectDropTarget,
       isDragging,
@@ -104,7 +105,13 @@ class WidgetFrame extends Component {
 
     if (frameComponent) {
       // if user provided a custom frame,  use it
-      selected = createElement(frameComponent, {	children,	editable, title, onRemove: this.remove }); // eslint-disable-line max-len
+      selected = createElement(frameComponent, {
+        children,
+        editable,
+        title,
+        settings: frameSettings,
+        onRemove: this.remove,
+      });
     } else {
       // else use the default frame
       selected = (

--- a/lib/components/Widgets.js
+++ b/lib/components/Widgets.js
@@ -20,6 +20,7 @@ const Widgets = ({ widgets, widgetTypes, onRemove, layout, columnIndex, rowIndex
         widgetIndex={index}
         editable={editable}
         frameComponent={frameComponent}
+        frameSettings={widgetTypes[widget.key].frameSettings}
         onMove={onMove}
       >
         {

--- a/test/components/WidgetFrame.spec.js
+++ b/test/components/WidgetFrame.spec.js
@@ -131,6 +131,9 @@ describe('<WidgetFrame />', () => {
     let title = 'Widget Title';
     let OriginalWidgetFrame = WidgetFrame.DecoratedComponent;
     let identity = (el) => el;
+    let settings = {
+      color: '#E140AD',
+    };
     const component = mount(
       <ContainerWithDndContext>
         <OriginalWidgetFrame
@@ -139,6 +142,7 @@ describe('<WidgetFrame />', () => {
           onRemove={onRemove}
           title={title}
           frameComponent={TestCustomFrame}
+          frameSettings={settings}
           connectDragSource={identity}
           connectDropTarget={identity}
         />
@@ -148,5 +152,6 @@ describe('<WidgetFrame />', () => {
     expect(component.find(TestCustomFrame).first().prop('children')).to.equal(children);
     expect(component.find(TestCustomFrame).first().prop('editable')).to.equal(editable);
     expect(component.find(TestCustomFrame).first().prop('title')).to.equal(title);
+    expect(component.find(TestCustomFrame).first().prop('settings')).to.equal(settings);
   });
 });

--- a/test/components/Widgets.spec.js
+++ b/test/components/Widgets.spec.js
@@ -6,6 +6,14 @@ import WidgetFrame from '../../lib/components/WidgetFrame';
 import TestComponent from '../fake/TestComponent';
 
 describe('<Widgets />', () => {
+  const layout = {};
+  const columnIndex = 5;
+  const rowIndex = 6;
+  const widgetIndex = 0;
+  const editable = false;
+  const frame = () => {};
+  const onRemove = () => {};
+
   it('Should render widgets with widget frames', () => {
     const widgets = [{ key: 'HelloWorld' }];
     const widgetTypes = {
@@ -26,14 +34,6 @@ describe('<Widgets />', () => {
         title: 'Sample Hello World App',
       },
     };
-
-    const layout = {};
-    const columnIndex = 5;
-    const rowIndex = 6;
-    const widgetIndex = 0;
-    const editable = false;
-    const frame = () => {};
-    const onRemove = () => {};
 
     const component = shallow(
       <Widgets
@@ -57,6 +57,37 @@ describe('<Widgets />', () => {
     expect(component.find(WidgetFrame).at(0).prop('editable')).to.equal(editable);
     expect(component.find(WidgetFrame).at(0).prop('frameComponent')).to.equal(frame);
     expect(component.find(WidgetFrame).at(0).prop('onRemove')).to.equal(onRemove);
+  });
+
+  it('Should pass optional `frameSettings` to WidgetFrame', () => {
+    const widgets = [{ key: 'HelloWorld' }];
+    const widgetTypes = {
+      HelloWorld: {
+        type: TestComponent,
+        title: 'Sample Hello World App',
+        frameSettings: {
+          color: '#E140AD',
+        },
+      },
+    };
+
+    const component = shallow(
+      <Widgets
+        widgets={widgets}
+        widgetTypes={widgetTypes}
+        layout={layout}
+        columnIndex={columnIndex}
+        rowIndex={rowIndex}
+        widgetIndex={widgetIndex}
+        editable={editable}
+        frameComponent={frame}
+        onRemove={onRemove}
+      />
+    );
+
+    expect(component.find(WidgetFrame).at(0).prop('frameSettings')).to.deep.equal({
+      color: '#E140AD',
+    });
   });
 
   it('Frame should have the actual widget as children', () => {


### PR DESCRIPTION
Add an optional `frameSettings` property to `widgets` configuration. Those settings are passed to the instance of a custom `frameComponent`.

This allows custom widget frames to support per-component customisation.

For example, the following configuration:

```javascript
{
  widgets: {
      Widget1: {
          type: HelloWorld,
          title: 'Widget #1',
          frameSettings: {
              cardClass: 'border-primary',
              headerClass: 'bg-primary text-light',
          }
      },
      Widget2: {
          type: HelloWorld,
          title: 'Widget #2',
          frameSettings: {
              cardClass: 'border-light',
              headerClass: 'bg-light text-dark',
          }
      },
      Widget3: {
          type: HelloWorld,
          title: 'Widget #3',
          frameSettings: {
              cardClass: 'border-danger',
              headerClass: 'bg-danger text-light',
          }
      },
  },
  layout: {}
}
```

Uses different `frameSettings` to render:

![image](https://user-images.githubusercontent.com/1534822/36944284-b7949ef8-1f90-11e8-9ef9-5a479b516315.png)
